### PR TITLE
Development updates for 1.0.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "packfire/pdc",
     "description": "PDC for PHP - Smart little worker that checks on your PHP source code's class dependencies.",
-    "version": "1.0.5",
     "homepage": "http://mauris.sg/packfire/",
     "type": "library",
     "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "require":{
         "php": ">=5.3.0",
-        "packfire/options": "1.0.*",
+        "packfire/options": "1.1.*",
         "symfony/process": "2.1.*"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,24 +1,24 @@
 {
-    "hash": "791498c81dda0b5efd7c8591e5ad2255",
+    "hash": "27e524bc55d04b7cfd8d707a8b7c4730",
     "packages": [
         {
             "name": "packfire/options",
-            "version": "1.0.1",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/packfire/options",
-                "reference": "1.0.1"
+                "reference": "1.1.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/packfire/options/archive/1.0.1.zip",
-                "reference": "1.0.1",
+                "url": "https://github.com/packfire/options/archive/1.1.0.zip",
+                "reference": "1.1.0",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.0"
             },
-            "time": "2012-12-13 21:56:10",
+            "time": "2012-12-17 14:51:55",
             "type": "library",
             "installation-source": "dist",
             "autoload": {
@@ -26,7 +26,7 @@
                     "Packfire": "src"
                 }
             },
-            "notification-url": "http://packagist.org/downloads/",
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],

--- a/src/Packfire/PDC/Analyzer.php
+++ b/src/Packfire/PDC/Analyzer.php
@@ -135,12 +135,13 @@ class Analyzer {
         $report->processFile((string) $this->info);
         $report->increment(ReportType::FILE);
         $className = $this->info->getBasename('.php');
-        if (!$this->checkMismatch($className)) {
-            $report->increment(ReportType::MISMATCH, $className);
-        }
 
         $namespace = $this->fetchNamespace();
-        if (!$namespace) {
+        if ($namespace) {
+            if (!$this->checkMismatch($className)) {
+                $report->increment(ReportType::MISMATCH, $className);
+            }
+        } else {
             $report->increment(ReportType::NO_NAMESPACE);
         }
 

--- a/src/Packfire/PDC/PDC.php
+++ b/src/Packfire/PDC/PDC.php
@@ -108,6 +108,7 @@ class PDC {
 
             $paths = explode(PATH_SEPARATOR, $this->path);
             foreach($paths as $path) {
+                echo "Checking \"$path\"...\n\n";
                 $iterator = new \RecursiveIteratorIterator(
                                 new \RecursiveDirectoryIterator($path),
                                 \RecursiveIteratorIterator::CHILD_FIRST);

--- a/src/Packfire/PDC/PDC.php
+++ b/src/Packfire/PDC/PDC.php
@@ -11,7 +11,7 @@
 
 namespace Packfire\PDC;
 
-use Packfire\Command\OptionSet;
+use Packfire\Options\OptionSet;
 use Packfire\PDC\Toolbelt;
 use Packfire\PDC\Report\Report;
 use Packfire\PDC\Report\ReportType;

--- a/src/Packfire/PDC/PDC.php
+++ b/src/Packfire/PDC/PDC.php
@@ -89,27 +89,33 @@ class PDC {
             echo $this->optionSet->help();
         }else{
             $startTime = microtime(true);
-            $iterator = new \RecursiveIteratorIterator(
-                            new \RecursiveDirectoryIterator($this->path),
-                            \RecursiveIteratorIterator::CHILD_FIRST);
+
+            // perform inclusion of autoloader / performing bootstrap once
             if ($this->autoloader) {
                 require $this->autoloader;
             } elseif (is_file('vendor/autoload.php')) { // autodetect composer's autoloader
                 include('vendor/autoload.php');
             }
 
-            $report = new Report();
-            $report->add(ReportType::FILE, new ReportIndex('%d files checked'));
-            $report->add(ReportType::NO_NAMESPACE, new ReportIndex('%d files with no namespace declaration', 'No namespace found'));
-            $report->add(ReportType::MISMATCH, new ReportIndex('%d file and class name mismatch', 'File and class name mismatch'));
-            $report->add(ReportType::NOT_FOUND, new ReportIndex('%d dependencies not found', 'Not found'));
-            $report->add(ReportType::UNUSED, new ReportIndex('%d usused dependncies found', 'Unused'));
+            $paths = explode(PATH_SEPARATOR, $this->path);
+            foreach($paths as $path) {
+                $iterator = new \RecursiveIteratorIterator(
+                                new \RecursiveDirectoryIterator($path),
+                                \RecursiveIteratorIterator::CHILD_FIRST);
 
-            foreach ($iterator as $path) {
-                $extension = pathinfo($path->getFilename(), PATHINFO_EXTENSION);
-                if ($path->isFile() && $extension == 'php') {
-                    $analyzer = new Analyzer($path);
-                    $analyzer->analyze($report);
+                $report = new Report();
+                $report->add(ReportType::FILE, new ReportIndex('%d files checked'));
+                $report->add(ReportType::NO_NAMESPACE, new ReportIndex('%d files with no namespace declaration', 'No namespace found'));
+                $report->add(ReportType::MISMATCH, new ReportIndex('%d file and class name mismatch', 'File and class name mismatch'));
+                $report->add(ReportType::NOT_FOUND, new ReportIndex('%d dependencies not found', 'Not found'));
+                $report->add(ReportType::UNUSED, new ReportIndex('%d usused dependncies found', 'Unused'));
+
+                foreach ($iterator as $file) {
+                    $extension = pathinfo($file->getFilename(), PATHINFO_EXTENSION);
+                    if ($file->isFile() && $extension == 'php') {
+                        $analyzer = new Analyzer($file);
+                        $analyzer->analyze($report);
+                    }
                 }
             }
 

--- a/src/Packfire/PDC/PDC.php
+++ b/src/Packfire/PDC/PDC.php
@@ -97,18 +97,19 @@ class PDC {
                 include('vendor/autoload.php');
             }
 
+            // initialize report generation sequence
+            $report = new Report();
+            $report->add(ReportType::FILE, new ReportIndex('%d files checked'));
+            $report->add(ReportType::NO_NAMESPACE, new ReportIndex('%d files with no namespace declaration', 'No namespace found'));
+            $report->add(ReportType::MISMATCH, new ReportIndex('%d file and class name mismatch', 'File and class name mismatch'));
+            $report->add(ReportType::NOT_FOUND, new ReportIndex('%d dependencies not found', 'Not found'));
+            $report->add(ReportType::UNUSED, new ReportIndex('%d usused dependncies found', 'Unused'));
+
             $paths = explode(PATH_SEPARATOR, $this->path);
             foreach($paths as $path) {
                 $iterator = new \RecursiveIteratorIterator(
                                 new \RecursiveDirectoryIterator($path),
                                 \RecursiveIteratorIterator::CHILD_FIRST);
-
-                $report = new Report();
-                $report->add(ReportType::FILE, new ReportIndex('%d files checked'));
-                $report->add(ReportType::NO_NAMESPACE, new ReportIndex('%d files with no namespace declaration', 'No namespace found'));
-                $report->add(ReportType::MISMATCH, new ReportIndex('%d file and class name mismatch', 'File and class name mismatch'));
-                $report->add(ReportType::NOT_FOUND, new ReportIndex('%d dependencies not found', 'Not found'));
-                $report->add(ReportType::UNUSED, new ReportIndex('%d usused dependncies found', 'Unused'));
 
                 foreach ($iterator as $file) {
                     $extension = pathinfo($file->getFilename(), PATHINFO_EXTENSION);

--- a/src/Packfire/PDC/PDC.php
+++ b/src/Packfire/PDC/PDC.php
@@ -99,7 +99,8 @@ class PDC {
 
             // initialize report generation sequence
             $report = new Report();
-            $report->add(ReportType::FILE, new ReportIndex('%d files checked'));
+            $fileReport = new ReportIndex('%d files checked');
+            $report->add(ReportType::FILE, $fileReport);
             $report->add(ReportType::NO_NAMESPACE, new ReportIndex('%d files with no namespace declaration', 'No namespace found'));
             $report->add(ReportType::MISMATCH, new ReportIndex('%d file and class name mismatch', 'File and class name mismatch'));
             $report->add(ReportType::NOT_FOUND, new ReportIndex('%d dependencies not found', 'Not found'));
@@ -118,6 +119,10 @@ class PDC {
                         $analyzer->analyze($report);
                     }
                 }
+            }
+
+            if($fileReport->count() == 0){
+                echo "Warning: No files checked\n\n";
             }
 
             echo $report->report();


### PR DESCRIPTION
- multiple path testing. now PDC accepts PATH_SEPARATOR separated paths to test multiple path
- updated Packfire\Options
- Better responses from CLI tool
- Fixed issue on duplicated Missing Namespace and Mismatch Classname errors on files without namespace
