### PR TITLE
Development updates for 1.0.7

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -14,5 +14,5 @@ require(__DIR__ . '/../src/Packfire/PDC/Bootstrap.php');
 
 use Packfire\PDC\Compiler;
 
-$pdc = new Compiler();
-$pdc->compile();
+$compiler = new Compiler('pdc.phar');
+$compiler->build();

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,6 @@
         "symfony/process": "2.1.*"
     },
     "autoload": {
-        "psr-0": {"Packfire\\PDC": "src/Packfire"}
+        "psr-0": {"Packfire\\PDC": "src/"}
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
     "require":{
         "php": ">=5.3.0",
         "packfire/options": "1.1.*",
-        "symfony/process": "2.1.*"
+        "symfony/process": "2.1.*",
+        "packfire/concrete": "1.0.*"
     },
     "autoload": {
         "psr-0": {"Packfire\\PDC": "src/"}

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,6 @@
         "symfony/process": "2.1.*"
     },
     "autoload": {
-        "psr-0": {"Packfire": "src/"}
+        "psr-0": {"Packfire\\PDC": "src/Packfire"}
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,5 +1,5 @@
 {
-    "hash": "27e524bc55d04b7cfd8d707a8b7c4730",
+    "hash": "29054a55e2733862df5f85a2e1c11f79",
     "packages": [
         {
             "name": "packfire/options",

--- a/composer.lock
+++ b/composer.lock
@@ -1,29 +1,76 @@
 {
-    "hash": "29054a55e2733862df5f85a2e1c11f79",
+    "hash": "9b85c5c2b989c8283e2025ec7e9eb9cb",
     "packages": [
         {
-            "name": "packfire/options",
-            "version": "1.1.0",
+            "name": "packfire/concrete",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/packfire/options",
-                "reference": "1.1.0"
+                "url": "https://github.com/packfire/concrete",
+                "reference": "1.0.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/packfire/options/archive/1.1.0.zip",
-                "reference": "1.1.0",
+                "url": "https://github.com/packfire/concrete/archive/1.0.0.zip",
+                "reference": "1.0.0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "symfony/process": "2.1.*"
+            },
+            "time": "2012-12-24 13:05:35",
+            "type": "library",
+            "installation-source": "dist",
+            "autoload": {
+                "psr-0": {
+                    "Packfire\\Concrete": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sam-Mauris Yong",
+                    "email": "mauris@hotmail.sg",
+                    "homepage": "http://mauris.sg/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Packfire Concrete: PHAR compiler for PHP-CLI applications",
+            "homepage": "http://mauris.sg/packfire/",
+            "keywords": [
+                "php",
+                "cli",
+                "compiler",
+                "phar"
+            ]
+        },
+        {
+            "name": "packfire/options",
+            "version": "1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/packfire/options",
+                "reference": "1.1.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://github.com/packfire/options/archive/1.1.2.zip",
+                "reference": "1.1.2",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.0"
             },
-            "time": "2012-12-17 14:51:55",
+            "time": "2012-12-24 12:35:55",
             "type": "library",
             "installation-source": "dist",
             "autoload": {
                 "psr-0": {
-                    "Packfire": "src"
+                    "Packfire\\Options": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -50,29 +97,24 @@
         },
         {
             "name": "symfony/process",
-            "version": "v2.1.4",
+            "version": "v2.1.6",
             "target-dir": "Symfony/Component/Process",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Process",
-                "reference": "v2.1.4"
+                "reference": "v2.1.6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/symfony/Process/archive/v2.1.4.zip",
-                "reference": "v2.1.4",
+                "url": "https://github.com/symfony/Process/archive/v2.1.6.zip",
+                "reference": "v2.1.6",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
-            "time": "2012-11-19 20:53:52",
+            "time": "2012-12-19 13:27:19",
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.1-dev"
-                }
-            },
             "installation-source": "dist",
             "autoload": {
                 "psr-0": {

--- a/src/Packfire/PDC/Compiler.php
+++ b/src/Packfire/PDC/Compiler.php
@@ -11,7 +11,8 @@
 
 namespace Packfire\PDC;
 
-use Symfony\Component\Process\Process;
+use Packfire\Concrete\Compiler as CoreCompiler;
+use Packfire\Concrete\Processor\StripWhiteSpace;
 
 /**
  * Helps to provide compilation into a PHAR binary
@@ -24,78 +25,20 @@ use Symfony\Component\Process\Process;
  * @link https://github.com/packfire/pdc/
  */
 
-class Compiler {
+class Compiler extends CoreCompiler {
     
-    private $version;
-    
-    private $phar;
-    
-    private $strip = true;
-    
-    private function loadVersion(){
-        $process = new Process('git log --pretty="%h" -n1 HEAD', __DIR__);
-        if ($process->run() != 0) {
-            throw new \RuntimeException('Can\'t run "git log". You must compile from git repository clone and that git binary is installed.');
-        }
-        $this->version = trim($process->getOutput());
-
-        $processTag = new Process('git describe --tags HEAD');
-        if ($processTag->run() == 0) {
-            $this->version = trim($processTag->getOutput());
-        }
-    }
-    
-    public function compile($pharFile = 'pdc.phar'){
-        if(is_file($pharFile)){
-            @unlink($pharFile);
-        }
-        $this->loadVersion();
-        $this->phar = new \Phar($pharFile, 0, 'pdc.phar');
-        $this->phar->setSignatureAlgorithm(\Phar::SHA1);
+    protected function compile(){
+        $this->processor = new StripWhiteSpace();
         $this->addFile(new \SplFileInfo(__DIR__ . '/../../../license'));
-        $this->phar->startBuffering();
         $this->addFolder(__DIR__ . '/../../');
         $this->addFolder(__DIR__ . '/../../../bin/');
-        $this->addFolder(__DIR__ . '/../../../vendor/');
-        $this->addFolder(__DIR__ . '/../../../test/');
-        $this->addFile(new \SplFileInfo(__DIR__ . '/../../../phpunit.xml.dist'));
-        $this->phar->setStub($this->stub());
-        $this->phar->stopBuffering();
-        $this->strip = false;
+        $this->addFolder(__DIR__ . '/../../../vendor/composer');
+        $this->addFolder(__DIR__ . '/../../../vendor/packfire/options');
+        $this->addFile(new \SplFileInfo(__DIR__ . '/../../../vendor/autoload.php'));
+        $this->processor = null;
     }
     
-    private function addFolder($folder){
-        $iterator = new \RecursiveIteratorIterator(
-                        new \RecursiveDirectoryIterator($folder),
-                \RecursiveIteratorIterator::LEAVES_ONLY
-            );
-        foreach($iterator as $path){
-            $this->addFile($path);
-        }
-    }
-    
-    private function addFile($file) {
-        if($file->getRealPath() == __DIR__){
-            return;
-        }
-        $path = str_replace(
-                dirname(dirname(dirname(__DIR__))) . DIRECTORY_SEPARATOR,
-                '', $file->getRealPath());
-        $content = file_get_contents($file);
-        if ($this->strip) {
-            $content = $this->stripWhitespace($content);
-        }
-        if ($file->getBaseName() == 'license') {
-            $content = "\n\n$content\n\n";
-        }
-        
-        $content = preg_replace('{^#!/usr/bin/env php\s*}', '', $content);
-        $content = str_replace('{{version}}', $this->version, $content);
-
-        $this->phar->addFromString($path, $content);
-    }
-    
-    private function stub(){
+    protected function stub(){
         $stub = <<<'EOF'
 #!/usr/bin/env php
 <?php
@@ -114,7 +57,7 @@ EOF;
 
         // add warning once the phar is older than 30 days
         if (preg_match('{^[a-f0-9]+$}', $this->version)) {
-            $stub .= "echo 'Warning: this is not a stable build';\n";
+            $stub .= "echo \"Warning: this is not a stable build\\n\";\n";
         }
 
         return $stub . <<<'EOF'
@@ -122,29 +65,6 @@ require 'phar://pdc.phar/bin/pdc';
 
 __HALT_COMPILER();
 EOF;
-    }
-
-    private function stripWhitespace($source){
-        if (!function_exists('token_get_all')) {
-            return $source;
-        }
-
-        $output = '';
-        foreach (token_get_all($source) as $token) {
-            if (is_string($token)) {
-                $output .= $token;
-            } elseif (in_array($token[0], array(T_COMMENT, T_DOC_COMMENT))) {
-                //$output .= str_repeat("\n", substr_count($token[1], "\n"));
-            } elseif (T_WHITESPACE === $token[0]) {
-                // reduce wide spaces
-                $whitespace = preg_replace(array('{[ \t]+}', '{(\r\n|\r|\n)}', '{\n +}'), array(' ', "\n", "\n"), $token[1]);
-                $output .= $whitespace;
-            } else {
-                $output .= $token[1];
-            }
-        }
-
-        return $output;
     }
     
 }


### PR DESCRIPTION
- Use [Packfire Concrete](https://github.com/packfire/concrete) for PHAR compilation
- Symfony/Process update from 2.1.4 to 2.1.6
- PSR-0 namespace fix in Composer
